### PR TITLE
Removed OzStrips and vatACARS

### DIFF
--- a/Plugins.json
+++ b/Plugins.json
@@ -14,19 +14,9 @@
     "DllName": "SimulatorPlugin.dll",
     "Description": "Plugin that selects the aircraft in the simulator for vatSys."
   },
-  {
-    "Name": "maxrumsey/OzStrips",
-    "DllName": "ozstrips.dll",
-    "Description": "INTAS addon for vatSys."
-  },
     {
     "Name": "badvectors/VatpacPlugin",
     "DllName": "VatpacPlugin.dll",
     "Description": "Testing only."
-  },
-    {
-    "Name": "vatACARS/vatsys-plugin",
-    "DllName": "vatACARS.dll",
-    "Description": "Plugin to allow in client ACARS communication for the Hoppie network."
   }
 ]


### PR DESCRIPTION
Remove OzStrips, Now included in Australia vatSys profile and causes conflict with version included in profile.

Removed vatACARS, Development in limbo and dont have time to fix bugs that are being reported, removing to stop downloads from curious peopl